### PR TITLE
Open Things app first

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,11 @@
 chrome.browserAction.onClicked.addListener(function(tab) {
-	chrome.tabs.update(tab.id, {
-		url: 'things:add?title=' + encodeURIComponent(tab.title) + '&notes=' + encodeURIComponent(tab.url)
-	});
+  chrome.tabs.update(tab.id, {
+    url: 'things:'
+  }, function() {
+    setTimeout(function() {
+      chrome.tabs.update(tab.id, {
+        url: 'things:add?title=' + encodeURIComponent(tab.title) + '&notes=' + encodeURIComponent(tab.url)
+      });
+    }, 300);
+  });
 });


### PR DESCRIPTION
Open the Things app before adding the new task. This allows you to add tasks when Things is not open when clicking on the extension.