### PR TITLE
tabs.update() replaces iframe workaround

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,13 +7,8 @@ chrome.browserAction.onClicked.addListener(function(tab) {
 		// format selection if it is not null
 		selection = selection ? "\n" + selection[0]: "";
 
-		// per http://stackoverflow.com/a/29244120/518130
-		var frame = document.createElement("iframe");
-		frame.src = 'things:add?title=' + encodeURIComponent(tab.title) + '&notes=' + encodeURIComponent(tab.url + selection);
-
-		// Needs to be inserted into document to trigger load
-		document.body.appendChild(frame);
-		document.body.removeChild(frame);
+		var thingsURL = 'things:add?title=' + encodeURIComponent(tab.title) + '&notes=' + encodeURIComponent(tab.url + selection);
+  		chrome.tabs.update({ url: thingsURL });
 	});
 
 });


### PR DESCRIPTION
The iframe method in the currently released version of the extension doesn’t work anymore in my version of Chrome. Replacing the creation of an iframe with the chrome.tabs.update() method works just as well as the previous method did and is cleaner.