### PR TITLE
Add show-quick-entry=true

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,9 @@ chrome.browserAction.onClicked.addListener(function(tab) {
 		// format selection if it is not null
 		selection = selection ? "\n" + selection[0]: "";
 
-		var thingsURL = 'things:add?title=' + encodeURIComponent(tab.title) + '&notes=' + encodeURIComponent(tab.url + selection);
+		// Things 3.4 URL Scheme
+		// https://support.culturedcode.com/customer/en/portal/articles/2803573
+		var thingsURL = 'things:///add?show-quick-entry=true&title=' + encodeURIComponent(tab.title) + '&notes=' + encodeURIComponent(tab.url + selection);
   		chrome.tabs.update({ url: thingsURL });
 	});
 


### PR DESCRIPTION
Things 3.4 contains a big update to the [URL Scheme](https://support.culturedcode.com/customer/en/portal/articles/2803573). This PR adds the `show-quick-entry=true` parameter to restore behavior on newer versions of Things. Without this clicking the button in Chrome appears to do nothing, but it is silently adding todos to the Things Inbox.

I haven't tested this on 3.3, but I assume older versions of the app would ignore the `show-quick-entry` parameter.